### PR TITLE
move helper to end of class

### DIFF
--- a/solutions/ItemInventoryServiceImpl.java.ex4.start
+++ b/solutions/ItemInventoryServiceImpl.java.ex4.start
@@ -20,45 +20,6 @@ public class ItemInventoryServiceImpl implements ItemInventoryService {
 
     private ItemDao itemDao;
 
-    private boolean isRetryError(UnableToExecuteStatementException exception) {
-
-        // Helper function. 
-        // Once we've caught the UnableToExecuteStatementException,
-        // We'll check the cause to determine if it's a retry error
-        Throwable cause = exception.getCause(); 
-        log.error(String.format("ENCOUNTERED  %s", cause.toString()));
-
-        // We are looking for a type of PSQLException, "TransactionRetryError"
-        if (cause instanceof PSQLException) {
-            PSQLException psqlException = (PSQLException) cause;
-
-            /**
-             * The SQL State code 40001 refers to RETRY_WRITE_TOO_OLD error.
-             * This error occurs when a transaction A tries to write to a row R, 
-             * but another transaction B that was supposed to be serialized after A 
-             * (i.e., had been assigned a higher timestamp), has already written to 
-             * that row R, and has already committed. 
-             * 
-             * This is a common error when you have too much contention in your workload.
-             * 
-             * Ensure the SQL State code is 40001
-             */
-            if ("40001".equals(psqlException.getSQLState())) {
-
-                // Since we've encountered UnableToExecuteStatementException, with a cause
-                // of PSQLException with an error code of 40001 (RETRY_WRITE_TOO_OLD), 
-                // it can only be a retry error.
-                return true;
-
-            }
-
-        }
-
-        // If we reach this point, it wasn't a retry error.
-        return false;
-
-    }
-
     public ItemInventoryServiceImpl(ItemDao itemDao) {
         this.itemDao = itemDao;
     }
@@ -125,5 +86,44 @@ public class ItemInventoryServiceImpl implements ItemInventoryService {
         }  // End of catch block
 
     } // END OF EXERCISES; DO NOT MODIFY ANYTHING BEYOND THIS POINT
+
+    private boolean isRetryError(UnableToExecuteStatementException exception) {
+
+        // Helper function. 
+        // Once we've caught the UnableToExecuteStatementException,
+        // We'll check the cause to determine if it's a retry error
+        Throwable cause = exception.getCause(); 
+        log.error(String.format("ENCOUNTERED  %s", cause.toString()));
+
+        // We are looking for a type of PSQLException, "TransactionRetryError"
+        if (cause instanceof PSQLException) {
+            PSQLException psqlException = (PSQLException) cause;
+
+            /**
+             * The SQL State code 40001 refers to RETRY_WRITE_TOO_OLD error.
+             * This error occurs when a transaction A tries to write to a row R, 
+             * but another transaction B that was supposed to be serialized after A 
+             * (i.e., had been assigned a higher timestamp), has already written to 
+             * that row R, and has already committed. 
+             * 
+             * This is a common error when you have too much contention in your workload.
+             * 
+             * Ensure the SQL State code is 40001
+             */
+            if ("40001".equals(psqlException.getSQLState())) {
+
+                // Since we've encountered UnableToExecuteStatementException, with a cause
+                // of PSQLException with an error code of 40001 (RETRY_WRITE_TOO_OLD), 
+                // it can only be a retry error.
+                return true;
+
+            }
+
+        }
+
+        // If we reach this point, it wasn't a retry error.
+        return false;
+
+    }
 
 }

--- a/solutions/ItemInventoryServiceImpl.java.ex5.start
+++ b/solutions/ItemInventoryServiceImpl.java.ex5.start
@@ -20,45 +20,6 @@ public class ItemInventoryServiceImpl implements ItemInventoryService {
 
     private ItemDao itemDao;
 
-    private boolean isRetryError(UnableToExecuteStatementException exception) {
-
-        // Helper function. 
-        // Once we've caught the UnableToExecuteStatementException,
-        // We'll check the cause to determine if it's a retry error
-        Throwable cause = exception.getCause(); 
-        log.error(String.format("ENCOUNTERED  %s", cause.toString()));
-
-        // We are looking for a type of PSQLException, "TransactionRetryError"
-        if (cause instanceof PSQLException) {
-            PSQLException psqlException = (PSQLException) cause;
-
-            /**
-             * The SQL State code 40001 refers to RETRY_WRITE_TOO_OLD error.
-             * This error occurs when a transaction A tries to write to a row R, 
-             * but another transaction B that was supposed to be serialized after A 
-             * (i.e., had been assigned a higher timestamp), has already written to 
-             * that row R, and has already committed. 
-             * 
-             * This is a common error when you have too much contention in your workload.
-             * 
-             * Ensure the SQL State code is 40001
-             */
-            if ("40001".equals(psqlException.getSQLState())) {
-
-                // Since we've encountered UnableToExecuteStatementException, with a cause
-                // of PSQLException with an error code of 40001 (RETRY_WRITE_TOO_OLD), 
-                // it can only be a retry error.
-                return true;
-
-            }
-
-        }
-
-        // If we reach this point, it wasn't a retry error.
-        return false;
-
-    }
-
     public ItemInventoryServiceImpl(ItemDao itemDao) {
         this.itemDao = itemDao;
     }
@@ -127,5 +88,45 @@ public class ItemInventoryServiceImpl implements ItemInventoryService {
         }  // End of while block
 
     } // END OF EXERCISE; DO NOT MODIFY ANYTHING BEYOND THIS POINT
+
+
+    private boolean isRetryError(UnableToExecuteStatementException exception) {
+
+        // Helper function. 
+        // Once we've caught the UnableToExecuteStatementException,
+        // We'll check the cause to determine if it's a retry error
+        Throwable cause = exception.getCause(); 
+        log.error(String.format("ENCOUNTERED  %s", cause.toString()));
+
+        // We are looking for a type of PSQLException, "TransactionRetryError"
+        if (cause instanceof PSQLException) {
+            PSQLException psqlException = (PSQLException) cause;
+
+            /**
+             * The SQL State code 40001 refers to RETRY_WRITE_TOO_OLD error.
+             * This error occurs when a transaction A tries to write to a row R, 
+             * but another transaction B that was supposed to be serialized after A 
+             * (i.e., had been assigned a higher timestamp), has already written to 
+             * that row R, and has already committed. 
+             * 
+             * This is a common error when you have too much contention in your workload.
+             * 
+             * Ensure the SQL State code is 40001
+             */
+            if ("40001".equals(psqlException.getSQLState())) {
+
+                // Since we've encountered UnableToExecuteStatementException, with a cause
+                // of PSQLException with an error code of 40001 (RETRY_WRITE_TOO_OLD), 
+                // it can only be a retry error.
+                return true;
+
+            }
+
+        }
+
+        // If we reach this point, it wasn't a retry error.
+        return false;
+
+    }
 
 }

--- a/solutions/ItemInventoryServiceImpl.java.solution
+++ b/solutions/ItemInventoryServiceImpl.java.solution
@@ -20,45 +20,6 @@ public class ItemInventoryServiceImpl implements ItemInventoryService {
 
     private ItemDao itemDao;
 
-    private boolean isRetryError(UnableToExecuteStatementException exception) {
-
-        // Helper function. 
-        // Once we've caught the UnableToExecuteStatementException,
-        // We'll check the cause to determine if it's a retry error
-        Throwable cause = exception.getCause(); 
-        log.error(String.format("ENCOUNTERED  %s", cause.toString()));
-
-        // We are looking for a type of PSQLException, "TransactionRetryError"
-        if (cause instanceof PSQLException) {
-            PSQLException psqlException = (PSQLException) cause;
-
-            /**
-             * The SQL State code 40001 refers to RETRY_WRITE_TOO_OLD error.
-             * This error occurs when a transaction A tries to write to a row R, 
-             * but another transaction B that was supposed to be serialized after A 
-             * (i.e., had been assigned a higher timestamp), has already written to 
-             * that row R, and has already committed. 
-             * 
-             * This is a common error when you have too much contention in your workload.
-             * 
-             * Ensure the SQL State code is 40001
-             */
-            if ("40001".equals(psqlException.getSQLState())) {
-
-                // Since we've encountered UnableToExecuteStatementException, with a cause
-                // of PSQLException with an error code of 40001 (RETRY_WRITE_TOO_OLD), 
-                // it can only be a retry error.
-                return true;
-
-            }
-
-        }
-
-        // If we reach this point, it wasn't a retry error.
-        return false;
-
-    }
-
     public ItemInventoryServiceImpl(ItemDao itemDao) {
         this.itemDao = itemDao;
     }
@@ -125,5 +86,44 @@ public class ItemInventoryServiceImpl implements ItemInventoryService {
         }  // End of while block
 
     } // END OF EXERCISE; DO NOT MODIFY ANYTHING BEYOND THIS POINT
+
+    private boolean isRetryError(UnableToExecuteStatementException exception) {
+
+        // Helper function. 
+        // Once we've caught the UnableToExecuteStatementException,
+        // We'll check the cause to determine if it's a retry error
+        Throwable cause = exception.getCause(); 
+        log.error(String.format("ENCOUNTERED  %s", cause.toString()));
+
+        // We are looking for a type of PSQLException, "TransactionRetryError"
+        if (cause instanceof PSQLException) {
+            PSQLException psqlException = (PSQLException) cause;
+
+            /**
+             * The SQL State code 40001 refers to RETRY_WRITE_TOO_OLD error.
+             * This error occurs when a transaction A tries to write to a row R, 
+             * but another transaction B that was supposed to be serialized after A 
+             * (i.e., had been assigned a higher timestamp), has already written to 
+             * that row R, and has already committed. 
+             * 
+             * This is a common error when you have too much contention in your workload.
+             * 
+             * Ensure the SQL State code is 40001
+             */
+            if ("40001".equals(psqlException.getSQLState())) {
+
+                // Since we've encountered UnableToExecuteStatementException, with a cause
+                // of PSQLException with an error code of 40001 (RETRY_WRITE_TOO_OLD), 
+                // it can only be a retry error.
+                return true;
+
+            }
+
+        }
+
+        // If we reach this point, it wasn't a retry error.
+        return false;
+
+    }
 
 }

--- a/src/main/java/com/cockroachlabs/university/javatransactions/service/ItemInventoryServiceImpl.java
+++ b/src/main/java/com/cockroachlabs/university/javatransactions/service/ItemInventoryServiceImpl.java
@@ -20,45 +20,6 @@ public class ItemInventoryServiceImpl implements ItemInventoryService {
 
     private ItemDao itemDao;
 
-    private boolean isRetryError(UnableToExecuteStatementException exception) {
-
-        // Helper function. 
-        // Once we've caught the UnableToExecuteStatementException,
-        // We'll check the cause to determine if it's a retry error
-        Throwable cause = exception.getCause(); 
-        log.error(String.format("ENCOUNTERED  %s", cause.toString()));
-
-        // We are looking for a type of PSQLException, "TransactionRetryError"
-        if (cause instanceof PSQLException) {
-            PSQLException psqlException = (PSQLException) cause;
-
-            /**
-             * The SQL State code 40001 refers to RETRY_WRITE_TOO_OLD error.
-             * This error occurs when a transaction A tries to write to a row R, 
-             * but another transaction B that was supposed to be serialized after A 
-             * (i.e., had been assigned a higher timestamp), has already written to 
-             * that row R, and has already committed. 
-             * 
-             * This is a common error when you have too much contention in your workload.
-             * 
-             * Ensure the SQL State code is 40001
-             */
-            if ("40001".equals(psqlException.getSQLState())) {
-
-                // Since we've encountered UnableToExecuteStatementException, with a cause
-                // of PSQLException with an error code of 40001 (RETRY_WRITE_TOO_OLD), 
-                // it can only be a retry error.
-                return true;
-
-            }
-
-        }
-
-        // If we reach this point, it wasn't a retry error.
-        return false;
-
-    }
-
     public ItemInventoryServiceImpl(ItemDao itemDao) {
         this.itemDao = itemDao;
     }
@@ -125,5 +86,44 @@ public class ItemInventoryServiceImpl implements ItemInventoryService {
         }  // End of catch block
 
     } // END OF EXERCISES; DO NOT MODIFY ANYTHING BEYOND THIS POINT
+
+    private boolean isRetryError(UnableToExecuteStatementException exception) {
+
+        // Helper function. 
+        // Once we've caught the UnableToExecuteStatementException,
+        // We'll check the cause to determine if it's a retry error
+        Throwable cause = exception.getCause(); 
+        log.error(String.format("ENCOUNTERED  %s", cause.toString()));
+
+        // We are looking for a type of PSQLException, "TransactionRetryError"
+        if (cause instanceof PSQLException) {
+            PSQLException psqlException = (PSQLException) cause;
+
+            /**
+             * The SQL State code 40001 refers to RETRY_WRITE_TOO_OLD error.
+             * This error occurs when a transaction A tries to write to a row R, 
+             * but another transaction B that was supposed to be serialized after A 
+             * (i.e., had been assigned a higher timestamp), has already written to 
+             * that row R, and has already committed. 
+             * 
+             * This is a common error when you have too much contention in your workload.
+             * 
+             * Ensure the SQL State code is 40001
+             */
+            if ("40001".equals(psqlException.getSQLState())) {
+
+                // Since we've encountered UnableToExecuteStatementException, with a cause
+                // of PSQLException with an error code of 40001 (RETRY_WRITE_TOO_OLD), 
+                // it can only be a retry error.
+                return true;
+
+            }
+
+        }
+
+        // If we reach this point, it wasn't a retry error.
+        return false;
+
+    }
 
 }


### PR DESCRIPTION
change the `ItemInventoryServiceImpl` class members to the following order:
```
public class ItemInventoryServiceImpl implements ItemInventoryService {

  private ItemDao itemDao;

  public ItemInventoryServiceImpl(ItemDao itemDao) {...

  public void updateItemInventoryTxn(UUID itemId, int quantity) throws SQLException, InterruptedException {...

  public void updateItemInventory(UUID itemId, int quantity) throws SQLException, InterruptedException {...

  private boolean isRetryError(UnableToExecuteStatementException exception) {...

}
```
That gives us a typical Java order of class fields, constructors, behavior methods, and helper methods.